### PR TITLE
dash: wire up adding use devices

### DIFF
--- a/components/src/shared/dashboard/Modal/Modal.stories.tsx
+++ b/components/src/shared/dashboard/Modal/Modal.stories.tsx
@@ -28,6 +28,12 @@ Default.args = {
   icon: `info`,
 };
 
+export const Loading = Template.bind({});
+Loading.args = {
+  ...Default.args,
+  loading: true,
+};
+
 export const Destructive = Template.bind({});
 Destructive.args = {
   ...Default.args,

--- a/components/src/shared/dashboard/Modal/Modal.tsx
+++ b/components/src/shared/dashboard/Modal/Modal.tsx
@@ -4,13 +4,15 @@ import { Fragment } from 'react';
 import { Dialog, Transition } from '@headlessui/react';
 import Button from '../../Button';
 import { capitalize } from '../../lib/string';
+import LoadingSpinner from '../../LoadingSpinner';
 
 interface Props {
-  type: 'destructive' | 'default' | 'container';
+  type: 'destructive' | 'default' | 'container' | 'error';
   title: string;
   primaryButtonText?: string;
   secondaryButtonText?: string;
   isOpen: boolean;
+  loading?: boolean;
   onPrimaryClick(): unknown;
   onDismiss(): unknown;
   children?: React.ReactNode;
@@ -27,6 +29,7 @@ const Modal: React.FC<Props> = ({
   type,
   children,
   icon,
+  loading,
 }) => {
   if (!icon) {
     switch (type) {
@@ -39,6 +42,8 @@ const Modal: React.FC<Props> = ({
       case `container`:
         icon = `list`;
         break;
+      case `error`:
+        icon = `bug`;
     }
   }
 
@@ -68,76 +73,86 @@ const Modal: React.FC<Props> = ({
               leaveFrom="opacity-100 translate-y-0 sm:scale-100"
               leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
             >
-              <Dialog.Panel
-                className={cx(
-                  `relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg`,
-                  type === `container` && `lg:max-w-3xl`,
-                )}
-              >
-                {type === `container` ? (
-                  <div className="bg-white px-4 pt-5 pb-4 sm:p-4">
-                    <div className="flex justify-start items-center mb-5">
-                      <div className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-indigo-500 to-fuchsia-500">
-                        <i
-                          className={`fa fa-${icon} text-white -mt-px -translate-y-px text-2xl`}
-                        />
-                      </div>
-                      <Dialog.Title
-                        as="h3"
-                        className="text-xl ml-4 font-semibold leading-6 text-gray-900"
-                      >
-                        {capitalize(title)}
-                      </Dialog.Title>
-                    </div>
-                    <div>{children}</div>
-                  </div>
-                ) : (
-                  <div className="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
-                    <div className="sm:flex sm:items-start">
-                      <div className="mx-auto flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-indigo-500 to-fuchsia-500 sm:mx-0 zsm:h-10 zsm:w-10">
-                        <i
-                          className={`fa fa-${icon} text-white -mt-px -translate-y-px text-2xl`}
-                        />
-                      </div>
-                      <div className="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+              {loading ? (
+                <Dialog.Panel>
+                  <LoadingSpinner />
+                </Dialog.Panel>
+              ) : (
+                <Dialog.Panel
+                  className={cx(
+                    `relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg`,
+                    type === `container` && `lg:max-w-3xl`,
+                  )}
+                >
+                  {type === `container` ? (
+                    <div className="bg-white px-4 pt-5 pb-4 sm:p-4">
+                      <div className="flex justify-start items-center mb-5">
+                        <div className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-indigo-500 to-fuchsia-500">
+                          <i
+                            className={`fa fa-${icon} text-white -mt-px -translate-y-px text-2xl`}
+                          />
+                        </div>
                         <Dialog.Title
                           as="h3"
-                          className="text-lg font-semibold leading-6 text-gray-900"
+                          className="text-xl ml-4 font-semibold leading-6 text-gray-900"
                         >
                           {capitalize(title)}
                         </Dialog.Title>
-                        <div className="mt-2">
-                          {children && (
-                            <p className="text-sm text-gray-500">{children}</p>
-                          )}
+                      </div>
+                      <div>{children}</div>
+                    </div>
+                  ) : (
+                    <div className="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+                      <div className="sm:flex sm:items-start">
+                        <div className="mx-auto flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-indigo-500 to-fuchsia-500 sm:mx-0 zsm:h-10 zsm:w-10">
+                          <i
+                            className={`fa fa-${icon} text-white -mt-px -translate-y-px text-2xl`}
+                          />
+                        </div>
+                        <div className="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+                          <Dialog.Title
+                            as="h3"
+                            className="text-lg font-semibold leading-6 text-gray-900"
+                          >
+                            {capitalize(title)}
+                          </Dialog.Title>
+                          <div className="mt-2">
+                            {children && (
+                              <p className="text-sm text-gray-500">{children}</p>
+                            )}
+                          </div>
                         </div>
                       </div>
                     </div>
+                  )}
+                  <div className="sm:bg-gray-50 px-4 py-3 flex flex-col items-stretch sm:flex-row sm:px-6 sm:justify-end">
+                    {type !== `error` && (
+                      <Button
+                        type="button"
+                        small
+                        color="secondary-white"
+                        className="sm:mr-3 w-[100%] sm:w-auto mb-3 sm:mb-0"
+                        onClick={onDismiss}
+                      >
+                        {secondaryButtonText}
+                      </Button>
+                    )}
+                    <Button
+                      type="button"
+                      small
+                      color={
+                        type === `destructive` || type === `error`
+                          ? `secondary-warning`
+                          : `primary-violet`
+                      }
+                      className="w-[100%] sm:w-auto"
+                      onClick={type === `error` ? onDismiss : onPrimaryClick}
+                    >
+                      {primaryButtonText}
+                    </Button>
                   </div>
-                )}
-                <div className="sm:bg-gray-50 px-4 py-3 flex flex-col items-stretch sm:flex-row sm:px-6 sm:justify-end">
-                  <Button
-                    type="button"
-                    small
-                    color="secondary-white"
-                    className="sm:mr-3 w-[100%] sm:w-auto mb-3 sm:mb-0"
-                    onClick={onDismiss}
-                  >
-                    {secondaryButtonText}
-                  </Button>
-                  <Button
-                    type="button"
-                    small
-                    color={
-                      type === `destructive` ? `secondary-warning` : `primary-violet`
-                    }
-                    className="w-[100%] sm:w-auto"
-                    onClick={onPrimaryClick}
-                  >
-                    {primaryButtonText}
-                  </Button>
-                </div>
-              </Dialog.Panel>
+                </Dialog.Panel>
+              )}
             </Transition.Child>
           </div>
         </div>

--- a/components/src/shared/dashboard/Modal/RequestModal/RequestModal.stories.tsx
+++ b/components/src/shared/dashboard/Modal/RequestModal/RequestModal.stories.tsx
@@ -1,0 +1,36 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import RequestModal from './RequestModal';
+
+export default {
+  title: `Dashboard/Core/Modal/RequestModal`,
+  component: RequestModal,
+} as ComponentMeta<typeof RequestModal<UUID>>;
+
+const Template: ComponentStory<typeof RequestModal<UUID>> = (args) => (
+  <RequestModal {...args} />
+);
+
+export const Loading = Template.bind({});
+Loading.args = {
+  request: { state: `ongoing` },
+  successTitle: `Success`,
+  withPayload: (payload) => <h1>Got your payload here: {payload}</h1>,
+  withError: (err) => <h1>Got your error here, type: {err?.type}</h1>,
+  onDismiss: () => {},
+  onPrimaryClick: () => {},
+};
+
+export const Loaded = Template.bind({});
+Loaded.args = {
+  ...Loading.args,
+  request: { state: `succeeded`, payload: `123` },
+};
+
+export const Error = Template.bind({});
+Error.args = {
+  ...Loading.args,
+  request: {
+    state: `failed`,
+    error: { type: `actionable`, message: `Well shucks, we blew a gasket.` },
+  },
+};

--- a/components/src/shared/dashboard/Modal/RequestModal/RequestModal.tsx
+++ b/components/src/shared/dashboard/Modal/RequestModal/RequestModal.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import Modal from '../Modal';
+
+interface Props<Payload> {
+  request?: RequestState<Payload>;
+  successTitle: string;
+  errorTitle?: string;
+  withPayload: (payload: Payload) => React.ReactNode;
+  withError?: (error?: ApiError) => React.ReactNode;
+  onPrimaryClick(): unknown;
+  onDismiss(): unknown;
+  icon?: string;
+}
+
+function RequestModal<Payload>({
+  request,
+  successTitle,
+  errorTitle = `Error`,
+  withError,
+  withPayload,
+  onDismiss,
+  onPrimaryClick,
+  icon,
+}: Parameters<React.FC<Props<Payload>>>[0]): ReturnType<React.FC<Props<Payload>>> {
+  return (
+    <Modal
+      type={request?.state === `failed` ? `error` : `default`}
+      title={request?.state === `failed` ? errorTitle : successTitle}
+      loading={request?.state === `ongoing`}
+      isOpen={!!request}
+      onPrimaryClick={onPrimaryClick}
+      onDismiss={onDismiss}
+      icon={icon}
+    >
+      {request?.state === `succeeded` ? withPayload(request.payload) : null}
+      {request?.state === `failed`
+        ? withError
+          ? withError(request.error)
+          : `Sorry, something went wrong, please try again.`
+        : null}
+    </Modal>
+  );
+}
+
+export default RequestModal;

--- a/components/src/shared/dashboard/Modal/RequestModal/index.ts
+++ b/components/src/shared/dashboard/Modal/RequestModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './RequestModal';

--- a/components/src/shared/dashboard/Users/ConnectModal.tsx
+++ b/components/src/shared/dashboard/Users/ConnectModal.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import RequestModal from '../Modal/RequestModal';
+
+interface Props {
+  request?: RequestState<UUID>;
+  dismissAddDevice(): unknown;
+}
+
+const ConnectModal: React.FC<Props> = ({ dismissAddDevice, request }) => (
+  <RequestModal
+    request={request}
+    successTitle="Connection Token"
+    icon="desktop"
+    onPrimaryClick={dismissAddDevice}
+    onDismiss={dismissAddDevice}
+    withPayload={(payload) => (
+      <div className="space-y-3 mb-2">
+        <div>
+          Copy the token shown below, and paste it into the <i>Gertrude Mac App</i> to
+          connect the device.
+        </div>
+        <code className="block text-green-700">{payload}</code>
+        <div>
+          The device will show up in the list <em>once it has connected.</em>
+        </div>
+      </div>
+    )}
+  />
+);
+
+export default ConnectModal;

--- a/components/src/shared/dashboard/Users/EditUser/EditUser.tsx
+++ b/components/src/shared/dashboard/Users/EditUser/EditUser.tsx
@@ -13,6 +13,7 @@ import UserDevice from '../List/Card/Device';
 import PageHeading from '../../PageHeading';
 import { ConfirmDeleteEntity } from '../../Modal';
 import { inflect } from '../../../lib/string';
+import ConnectModal from '../ConnectModal';
 
 interface Props {
   isNew: boolean;
@@ -30,7 +31,10 @@ interface Props {
   keychains: SubcomponentsOmit<typeof KeychainCard, 'onRemove'>;
   devices: Subcomponents<typeof UserDevice>;
   deleteUser: ConfirmableEntityAction<void>;
+  startAddDevice(): unknown;
+  dismissAddDevice(): unknown;
   deleteDevice: ConfirmableEntityAction;
+  addDeviceRequest?: RequestState<UUID>;
   saveButtonDisabled: boolean;
   onSave(): unknown;
 }
@@ -54,8 +58,12 @@ const EditUser: React.FC<Props> = ({
   deleteUser,
   saveButtonDisabled,
   onSave,
+  dismissAddDevice,
+  addDeviceRequest,
+  startAddDevice,
 }) => (
   <div className="relative max-w-3xl">
+    <ConnectModal request={addDeviceRequest} dismissAddDevice={dismissAddDevice} />
     <ConfirmDeleteEntity type="device" action={deleteDevice} />
     <ConfirmDeleteEntity type="user" action={deleteUser} />
     <PageHeading icon={isNew ? `user-plus` : `pen`}>
@@ -89,7 +97,10 @@ const EditUser: React.FC<Props> = ({
             </button>
           </div>
         ))}
-        <button className="mt-5 text-violet-700 font-medium px-7 py-2 rounded-lg hover:bg-violet-100 self-end transition duration-100">
+        <button
+          onClick={startAddDevice}
+          className="mt-5 text-violet-700 font-medium px-7 py-2 rounded-lg hover:bg-violet-100 self-end transition duration-100"
+        >
           <i className="fa fa-plus mr-2" />
           Add device
         </button>

--- a/components/src/shared/dashboard/Users/List/Card/UserCard.tsx
+++ b/components/src/shared/dashboard/Users/List/Card/UserCard.tsx
@@ -13,6 +13,7 @@ type Props = {
   devices: Subcomponents<typeof UserDevice>;
   screenshotsEnabled: boolean;
   keystrokesEnabled: boolean;
+  addDevice(): unknown;
 };
 
 const UserCard: React.FC<Props> = ({
@@ -23,6 +24,7 @@ const UserCard: React.FC<Props> = ({
   devices,
   screenshotsEnabled,
   keystrokesEnabled,
+  addDevice,
 }) => (
   <div className="rounded-xl border flex flex-col justify-between shadow-lg w-full bg-white sm:min-w-[400px]">
     <div className="p-5">
@@ -94,7 +96,10 @@ const UserCard: React.FC<Props> = ({
         </div>
       )}
       <div className="flex justify-center mt-2">
-        <button className="mt-1 text-violet-600 px-7 py-2 rounded-lg hover:bg-gray-100 self-center transition duration-100">
+        <button
+          onClick={addDevice}
+          className="mt-1 text-violet-600 px-7 py-2 rounded-lg hover:bg-gray-100 self-center transition duration-100"
+        >
           <i className="fa fa-plus mr-2" />
           Add device
         </button>

--- a/components/src/shared/dashboard/Users/List/ListUsers.stories.tsx
+++ b/components/src/shared/dashboard/Users/List/ListUsers.stories.tsx
@@ -66,3 +66,20 @@ Default.args = {
     },
   ],
 };
+
+export const AddingDeviceLoading = Template.bind({});
+AddingDeviceLoading.args = {
+  ...Default.args,
+  addDeviceRequest: {
+    state: `ongoing`,
+  },
+};
+
+export const AddingDevice = Template.bind({});
+AddingDevice.args = {
+  ...Default.args,
+  addDeviceRequest: {
+    state: `succeeded`,
+    payload: `e8e65309-fe54-4eda-9f02-d1983d670d03`,
+  },
+};

--- a/components/src/shared/dashboard/Users/List/ListUsers.tsx
+++ b/components/src/shared/dashboard/Users/List/ListUsers.tsx
@@ -3,21 +3,35 @@ import Button from '../../../Button';
 import PageHeading from '../../PageHeading';
 import NoUsers from './NoUsers';
 import UserCard from './Card';
-import { Subcomponents } from '../../../types';
+import { SubcomponentsOmit } from '../../../types';
+import ConnectModal from '../ConnectModal';
 
 type Props = {
-  users: Subcomponents<typeof UserCard>;
+  users: SubcomponentsOmit<typeof UserCard, 'addDevice'>;
+  addDeviceRequest?: RequestState<UUID>;
+  startAddDevice(userId: UUID): unknown;
+  dismissAddDevice(): unknown;
 };
 
-const Users: React.FC<Props> = ({ users }) => (
+const Users: React.FC<Props> = ({
+  users,
+  addDeviceRequest,
+  startAddDevice,
+  dismissAddDevice,
+}) => (
   <div className="flex flex-col">
+    <ConnectModal request={addDeviceRequest} dismissAddDevice={dismissAddDevice} />
     <PageHeading icon="users">Users</PageHeading>
     <div className="mt-8 flex flex-col">
       {users.length > 0 ? (
         <>
           <div className="mb-16 grid grid-cols-1 lg+:grid-cols-2 gap-10 lg+:gap-8 xl:gap-10 2xl:grid-cols-3">
             {users.map((user) => (
-              <UserCard key={user.id} {...user} />
+              <UserCard
+                key={user.id}
+                addDevice={() => startAddDevice(user.id)}
+                {...user}
+              />
             ))}
           </div>
           <Button

--- a/components/src/shared/dashboard/types/GraphQL.ts
+++ b/components/src/shared/dashboard/types/GraphQL.ts
@@ -63,6 +63,14 @@ export interface CreateUserInput {
   screenshotsResolution?: number | null;
 }
 
+export interface CreateUserTokenInput {
+  deletedAt?: string | null;
+  deviceId?: UUID | null;
+  id?: UUID | null;
+  userId: UUID;
+  value?: UUID | null;
+}
+
 export interface CreateWaitlistedUserInput {
   email: string;
   id?: UUID | null;

--- a/dashboard/src/api/users/__generated__/CreateUserToken.ts
+++ b/dashboard/src/api/users/__generated__/CreateUserToken.ts
@@ -1,0 +1,23 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { CreateUserTokenInput } from './../../../../../components/src/shared/dashboard/types/GraphQL';
+
+// ====================================================
+// GraphQL mutation operation: CreateUserToken
+// ====================================================
+
+export interface CreateUserToken_token {
+  __typename: 'UserToken';
+  value: string;
+}
+
+export interface CreateUserToken {
+  token: CreateUserToken_token;
+}
+
+export interface CreateUserTokenVariables {
+  input: CreateUserTokenInput;
+}

--- a/dashboard/src/api/users/createUserToken.ts
+++ b/dashboard/src/api/users/createUserToken.ts
@@ -1,0 +1,19 @@
+import Result from '../Result';
+import { gql, mutate } from '../apollo';
+import * as T from './__generated__/CreateUserToken';
+
+export async function createUserToken(userId: UUID): Promise<Result<UUID, ApiError>> {
+  const result = await mutate<T.CreateUserToken, T.CreateUserTokenVariables>(
+    CREATE_MUTATION,
+    { input: { userId } },
+  );
+  return result.mapApi((data) => data.token.value);
+}
+
+const CREATE_MUTATION = gql`
+  mutation CreateUserToken($input: CreateUserTokenInput!) {
+    token: createUserToken(input: $input) {
+      value
+    }
+  }
+`;

--- a/dashboard/src/api/users/index.ts
+++ b/dashboard/src/api/users/index.ts
@@ -7,4 +7,5 @@ export { upsertUser } from './upsertUser';
 export { setUserKeychains } from './setUserKeychains';
 export { deleteDevice } from './deleteDevice';
 export { deleteUser } from './deleteUser';
+export { createUserToken } from './createUserToken';
 export type { User } from './types';

--- a/dashboard/src/components/routes/User.tsx
+++ b/dashboard/src/components/routes/User.tsx
@@ -14,6 +14,8 @@ import {
   userEntityDeleteCanceled,
   deleteDevice,
   deleteUser,
+  createUserToken,
+  addDeviceDismissed,
 } from '../../redux/slice-users';
 import { isDirty, Query, Req } from '../../redux/helpers';
 import {
@@ -109,6 +111,9 @@ export const queryProps: QueryProps<typeof EditUser, UUID> =
           confirm: () => dispatch(deleteDevice(deleteDeviceId ?? ``)),
           cancel: () => dispatch(userEntityDeleteCanceled(`device`)),
         },
+        startAddDevice: () => dispatch(createUserToken(id)),
+        dismissAddDevice: () => dispatch(addDeviceDismissed()),
+        addDeviceRequest: state.addDeviceRequest,
       }),
       false,
     ];

--- a/dashboard/src/components/routes/Users.tsx
+++ b/dashboard/src/components/routes/Users.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import Loading from '@shared/Loading';
 import ListUsers from '@dashboard/Users/List';
 import { useDispatch, useSelector } from '../../redux/hooks';
-import { fetchUsers } from '../../redux/slice-users';
+import { addDeviceDismissed, createUserToken, fetchUsers } from '../../redux/slice-users';
 import ApiErrorMessage from '../ApiErrorMessage';
 import { Family } from '@dashboard/types/GraphQL';
 import * as typesafe from '../../lib/typesafe';
@@ -10,8 +10,9 @@ import { isUnsaved } from '../shared/lib/id';
 
 const Users: React.FC = () => {
   const dispatch = useDispatch();
-  const { users, request } = useSelector((state) => ({
-    request: state.users.listRequest,
+  const { users, listRequest, addDeviceRequest } = useSelector((state) => ({
+    listRequest: state.users.listRequest,
+    addDeviceRequest: state.users.addDeviceRequest,
     users: typesafe
       .objectValues(state.users.users)
       .map((editable) => editable.original)
@@ -19,14 +20,14 @@ const Users: React.FC = () => {
   }));
 
   useEffect(() => {
-    request.state === `idle` && dispatch(fetchUsers());
-  }, [dispatch, request, request.state]);
+    listRequest.state === `idle` && dispatch(fetchUsers());
+  }, [dispatch, listRequest, listRequest.state]);
 
-  if (request.state === `failed`) {
-    return <ApiErrorMessage error={request.error} />;
+  if (listRequest.state === `failed`) {
+    return <ApiErrorMessage error={listRequest.error} />;
   }
 
-  if (request.state === `idle` || request.state === `ongoing`) {
+  if (listRequest.state === `idle` || listRequest.state === `ongoing`) {
     return <Loading />;
   }
 
@@ -49,6 +50,9 @@ const Users: React.FC = () => {
         screenshotsEnabled: resource.screenshotsEnabled,
         keystrokesEnabled: resource.keyloggingEnabled,
       }))}
+      startAddDevice={(userId) => dispatch(createUserToken(userId))}
+      dismissAddDevice={() => dispatch(addDeviceDismissed())}
+      addDeviceRequest={addDeviceRequest}
     />
   );
 };

--- a/dashboard/src/environment/ApiClient.ts
+++ b/dashboard/src/environment/ApiClient.ts
@@ -96,6 +96,9 @@ export const throwingApiClient: ApiClient = {
     deleteUser: () => {
       throw new Error(`ApiClient.users.deleteUser() not implemented.`);
     },
+    createUserToken: () => {
+      throw new Error(`ApiClient.users.createUserToken() not implemented.`);
+    },
   },
   signup: {
     joinWaitlist: () => {
@@ -181,6 +184,9 @@ export const noopApiClient: ApiClient = {
     },
     deleteUser: async () => {
       return Result.success(true);
+    },
+    createUserToken: async () => {
+      return Result.success(``);
     },
   },
   signup: {


### PR DESCRIPTION
closes https://github.com/gertrude-app/project/issues/54.

This PR add the ability to create a user token, which you do by pressing the add device button, either on the list users screen or on the individual edit user screen. Go ahead and test it out on staging please, it should work. Although you won't be able to plug the token into
 a Gertrude Mac App, that's OK.

I added another wrapper around our `Modal` component called a `<RequestModal />` which encapsulates the idea of showing a model that is driven by the _lifecycle of an API request._ So it has a loading state, and a successful results state which includes some sort of payload from the API, and a possible error state.