### PR TITLE
storybook: stabilize/improve modal overflow screenshot test

### DIFF
--- a/storybook/src/dash/Users/SuspendFilterRequestForm.stories.tsx
+++ b/storybook/src/dash/Users/SuspendFilterRequestForm.stories.tsx
@@ -37,9 +37,11 @@ export const Default: Story = {
     setDuration: () => {},
     setCustomDuration: () => {},
   },
+  // allow screenshotting open dropdown, verifying not cutoff
   play: async () => {
-    // @ts-ignore
-    document.querySelector(`button[aria-haspopup="listbox"]`)?.click();
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    const button = document.querySelector(`button[aria-haspopup="listbox"]`);
+    button instanceof HTMLElement && button.click();
   },
 };
 

--- a/storybook/visual-tests/run.ts
+++ b/storybook/visual-tests/run.ts
@@ -20,6 +20,10 @@ async function main(): Promise<void> {
     .map(([file, story]) => extractScreenshotTest(file, story))
     .filter(notNullish);
 
+  if (!tests.some((t) => t.id === `dashboard-users-suspendfilterrequestform--default`)) {
+    throw new Error(`story w/ custom wait not found, possibly renamed`);
+  }
+
   const browser = await puppeteer.launch({ headless: true, product: `chrome` });
   const page = await browser.newPage();
   const url = `http://localhost:4777/${process.env.CI ? `` : `iframe.html`}`;


### PR DESCRIPTION
@kiahjh a couple PR's back, you added `overflow-hidden` to the modal component, and i merged it, but it caused a bug where the dropdowns for filter suspension request durations where cutoff and not usable.  so, i added a little storybook trickery to screenshot that the dropdown could overflow in [this commit](https://github.com/jaredh159/gertrude-web/commit/bc60d2ccf93f9e994b6c8867fc5f1460f7507592).

but that test has been a little flaky, so this PR attempts to stabilize it, with a little timeout, and to force an error in the future if the test-id that i'm targeting changes.