### PR TITLE
dash: update to tanstack/react-query v5

### DIFF
--- a/dash/app/package.json
+++ b/dash/app/package.json
@@ -23,7 +23,7 @@
     "@shared/string": "workspace:*",
     "@shared/tailwind": "workspace:*",
     "@shared/ts-utils": "workspace:*",
-    "@tanstack/react-query": "4.29.12",
+    "@tanstack/react-query": "5.14.0",
     "classnames": "^2.3.1",
     "graphql": "^16.5.0",
     "immer": "10.0.2",

--- a/dash/app/src/components/routes/AdminSettings.tsx
+++ b/dash/app/src/components/routes/AdminSettings.tsx
@@ -74,9 +74,9 @@ const AdminSettings: React.FC = () => {
     },
   );
 
-  const notificationProps = makeNotificationProps(state, saveNotification.isLoading);
+  const notificationProps = makeNotificationProps(state, saveNotification.isPending);
 
-  if (query.isLoading) {
+  if (query.isPending) {
     return <Loading />;
   }
 

--- a/dash/app/src/components/routes/CombinedUsersActivityFeed.tsx
+++ b/dash/app/src/components/routes/CombinedUsersActivityFeed.tsx
@@ -35,7 +35,7 @@ const CombinedUsersActivityFeedRoute: React.FC = () => {
     },
   );
 
-  if (query.isLoading) {
+  if (query.isPending) {
     return <Loading />;
   }
 

--- a/dash/app/src/components/routes/CombinedUsersActivitySummaries.tsx
+++ b/dash/app/src/components/routes/CombinedUsersActivitySummaries.tsx
@@ -9,7 +9,7 @@ const CombinedUsersActivitySummariesRoute: React.FC = () => {
     Current.api.combinedUsersActivitySummaries(entireDays(14)),
   );
 
-  if (query.isLoading) {
+  if (query.isPending) {
     return <Loading />;
   }
 

--- a/dash/app/src/components/routes/Computer.tsx
+++ b/dash/app/src/components/routes/Computer.tsx
@@ -34,7 +34,7 @@ const Computer: React.FC = () => {
   const [releaseChannel, setReleaseChannel] = useState<ReleaseChannel>(`stable`);
 
   const zip = useZip(getComputer, latestAppVersions);
-  if (zip.isLoading) return <Loading />;
+  if (zip.isPending) return <Loading />;
   if (zip.isError) return <ApiErrorMessage error={zip.error} />;
   const [deviceData, appVersionsData] = zip.data;
 

--- a/dash/app/src/components/routes/Computers.tsx
+++ b/dash/app/src/components/routes/Computers.tsx
@@ -6,7 +6,7 @@ import Current from '../../environment';
 const Computers: React.FC = () => {
   const query = useQuery(Key.devices, Current.api.getDevices);
 
-  if (query.isLoading) {
+  if (query.isPending) {
     return <Loading />;
   }
 

--- a/dash/app/src/components/routes/Dashboard.tsx
+++ b/dash/app/src/components/routes/Dashboard.tsx
@@ -11,7 +11,7 @@ const DashboardRoute: React.FC = () => {
     Current.api.createPendingAppConnection({ userId }),
   );
 
-  if (widgetsQuery.isLoading) {
+  if (widgetsQuery.isPending) {
     return <Loading />;
   }
 

--- a/dash/app/src/components/routes/HollandTalk.tsx
+++ b/dash/app/src/components/routes/HollandTalk.tsx
@@ -57,7 +57,7 @@ const HollandTalk: React.FC = () => {
         >
           Submit <i className="fas fa-arrow-right ml-2" />
         </Button>
-        {subscription.isLoading && <Loading className="mt-6" />}
+        {subscription.isPending && <Loading className="mt-6" />}
         {!emailValid && subscription.isIdle && (
           <Message
             heading="Invalid email address"

--- a/dash/app/src/components/routes/Keychain.tsx
+++ b/dash/app/src/components/routes/Keychain.tsx
@@ -104,7 +104,7 @@ const Keychain: React.FC = () => {
       setDescription={(description) => dispatch({ type: `updateDesc`, description })}
       deleteKeychain={deleteKeychain}
       deleteKey={deleteKey}
-      saveButtonDisabled={saveKeychain.isLoading || !isDirty(editableKeychain)}
+      saveButtonDisabled={saveKeychain.isPending || !isDirty(editableKeychain)}
       onSave={() => saveKeychain.mutate(editableKeychain)}
       beginEditKey={(id) => dispatch({ type: `beginEditKey`, id })}
       updateEditingKey={(event) => dispatch({ type: `updateEditingKey`, event })}
@@ -112,7 +112,7 @@ const Keychain: React.FC = () => {
       onKeySave={() => saveKey.mutate(undefined)}
       onCreateNewKey={() => dispatch({ type: `createNewKey` })}
       keyModalSaveButtonDisabled={
-        toKeyRecord(state.editingKey) === null || saveKey.isLoading
+        toKeyRecord(state.editingKey) === null || saveKey.isPending
       }
     />
   );

--- a/dash/app/src/components/routes/Keychains.tsx
+++ b/dash/app/src/components/routes/Keychains.tsx
@@ -9,7 +9,7 @@ const Keychains: React.FC = () => {
     invalidating: [Key.adminKeychains],
   });
 
-  if (query.isLoading) {
+  if (query.isPending) {
     return <Loading />;
   }
 

--- a/dash/app/src/components/routes/Login.tsx
+++ b/dash/app/src/components/routes/Login.tsx
@@ -28,7 +28,7 @@ export const Login: React.FC = () => {
     return <Navigate to={redirectUrl ?? `/`} replace />;
   }
 
-  if (loginMutation.isLoading || requestMagicLink.isLoading) {
+  if (loginMutation.isPending || requestMagicLink.isPending) {
     return <FullscreenModalForm state="ongoing" />;
   }
 

--- a/dash/app/src/components/routes/MagicLink.tsx
+++ b/dash/app/src/components/routes/MagicLink.tsx
@@ -30,7 +30,7 @@ const MagicLink: React.FC = () => {
     return <FullscreenModalForm state="failed" error={error} />;
   }
 
-  if (query.isLoading) {
+  if (query.isPending) {
     return <FullscreenModalForm state="ongoing" />;
   }
 

--- a/dash/app/src/components/routes/Signup.tsx
+++ b/dash/app/src/components/routes/Signup.tsx
@@ -9,7 +9,7 @@ const Signup: React.FC = () => {
   const [password, setPassword] = useState(``);
   const signup = useMutation(() => Current.api.signup({ email, password }));
 
-  if (signup.isLoading) {
+  if (signup.isPending) {
     return <FullscreenModalForm state="ongoing" />;
   }
 

--- a/dash/app/src/components/routes/SuspendFilter.tsx
+++ b/dash/app/src/components/routes/SuspendFilter.tsx
@@ -51,7 +51,7 @@ const SuspendFilter: React.FC = () => {
     { invalidating: [queryKey], toast: `update:suspend-filter-request` },
   );
 
-  if (query.isLoading) {
+  if (query.isPending) {
     return <Loading />;
   }
 
@@ -95,7 +95,7 @@ const SuspendFilter: React.FC = () => {
         label: `Grant`,
         action: () => update.mutate(`accepted`),
         disabled:
-          update.isLoading ||
+          update.isPending ||
           update.isSuccess ||
           (state.grantedDurationInSeconds === `custom` &&
             (Number.isNaN(Number(state.grantedCustomDurationInMinutes)) ||

--- a/dash/app/src/components/routes/UnlockRequest/DenyUnlockRequest.tsx
+++ b/dash/app/src/components/routes/UnlockRequest/DenyUnlockRequest.tsx
@@ -23,7 +23,7 @@ const DenyUnlockRequest: React.FC = () => {
     });
   });
 
-  if (query.isLoading || deny.isLoading) {
+  if (query.isPending || deny.isPending) {
     return <LoadingModal />;
   }
 

--- a/dash/app/src/components/routes/UnlockRequest/EditUnlockRequestKey.tsx
+++ b/dash/app/src/components/routes/UnlockRequest/EditUnlockRequestKey.tsx
@@ -45,7 +45,7 @@ const EditUnlockRequestKey: React.FC = () => {
     return <ErrorModal error={query.error} />;
   }
 
-  if (query.isLoading || accept.isLoading || !key) {
+  if (query.isPending || accept.isPending || !key) {
     return <LoadingModal />;
   }
 

--- a/dash/app/src/components/routes/UnlockRequest/FetchUnlockRequest.tsx
+++ b/dash/app/src/components/routes/UnlockRequest/FetchUnlockRequest.tsx
@@ -8,7 +8,7 @@ const FetchUnlockRequest: React.FC = () => {
   const navigate = useNavigate();
   const query = useUnlockRequest(id);
 
-  if (query.isLoading) {
+  if (query.isPending) {
     return <LoadingModal />;
   }
 

--- a/dash/app/src/components/routes/UnlockRequest/ReviewUnlockRequest.tsx
+++ b/dash/app/src/components/routes/UnlockRequest/ReviewUnlockRequest.tsx
@@ -19,7 +19,7 @@ const ReviewUnlockRequestRoute: React.FC = () => {
   useUser(userId);
   useSelectableKeychains();
 
-  if (query.isLoading) {
+  if (query.isPending) {
     return <LoadingModal />;
   }
 

--- a/dash/app/src/components/routes/UnlockRequest/SelectUnlockRequestKeychain.tsx
+++ b/dash/app/src/components/routes/UnlockRequest/SelectUnlockRequestKeychain.tsx
@@ -9,7 +9,7 @@ const SelectUnlockRequestKeychain: React.FC = () => {
   const navigate = useNavigate();
   const query = useZip(useSelectableKeychains(), useUser(userId));
 
-  if (query.isLoading) {
+  if (query.isPending) {
     return <LoadingModal />;
   }
 

--- a/dash/app/src/components/routes/UnlockRequest/UserUnlockRequests.tsx
+++ b/dash/app/src/components/routes/UnlockRequest/UserUnlockRequests.tsx
@@ -11,7 +11,7 @@ const UserUnlockRequests: React.FC = () => {
     useUser(id),
   );
 
-  if (query.isLoading) {
+  if (query.isPending) {
     return <Loading />;
   }
 

--- a/dash/app/src/components/routes/UnlockRequest/UsersUnlockRequests.tsx
+++ b/dash/app/src/components/routes/UnlockRequest/UsersUnlockRequests.tsx
@@ -6,7 +6,7 @@ import { useQuery, Key } from '../../../hooks';
 const UsersUnlockRequests: React.FC = () => {
   const query = useQuery(Key.combinedUsersUnlockRequests, Current.api.getUnlockRequests);
 
-  if (query.isLoading) {
+  if (query.isPending) {
     return <Loading />;
   }
 

--- a/dash/app/src/components/routes/User.tsx
+++ b/dash/app/src/components/routes/User.tsx
@@ -110,7 +110,7 @@ const UserRoute: React.FC = () => {
       addDeviceRequest={ReqState.fromMutation(addDevice)}
       deleteDevice={deleteDevice}
       saveButtonDisabled={
-        !isDirty(state.user) || draft.name.trim() === `` || saveUser.isLoading
+        !isDirty(state.user) || draft.name.trim() === `` || saveUser.isPending
       }
       onSave={() => saveUser.mutate(user)}
       onAddKeychainClicked={() => dispatch({ type: `setAddingKeychain`, keychain: null })}

--- a/dash/app/src/components/routes/UserActivityFeed.tsx
+++ b/dash/app/src/components/routes/UserActivityFeed.tsx
@@ -35,7 +35,7 @@ const UserActivityFeedRoute: React.FC = () => {
     },
   );
 
-  if (query.isLoading) {
+  if (query.isPending) {
     return <Loading />;
   }
 

--- a/dash/app/src/components/routes/UserActivitySummaries.tsx
+++ b/dash/app/src/components/routes/UserActivitySummaries.tsx
@@ -12,7 +12,7 @@ const UserActivitySummariesRoute: React.FC = () => {
     Current.api.userActivitySummaries({ userId, dateRanges: entireDays(14) }),
   );
 
-  if (getSummaries.isLoading) {
+  if (getSummaries.isPending) {
     return <Loading />;
   }
 

--- a/dash/app/src/components/routes/Users.tsx
+++ b/dash/app/src/components/routes/Users.tsx
@@ -13,7 +13,7 @@ const Users: React.FC = () => {
     Current.api.createPendingAppConnection({ userId }),
   );
 
-  if (query.isLoading) {
+  if (query.isPending) {
     return <Loading />;
   }
 

--- a/dash/app/src/components/routes/VerifySignupEmail.tsx
+++ b/dash/app/src/components/routes/VerifySignupEmail.tsx
@@ -37,7 +37,7 @@ const VerifySignupEmail: React.FC = () => {
     );
   }
 
-  if (verification.isLoading) {
+  if (verification.isPending) {
     return <FullscreenModalForm state="ongoing" />;
   }
 

--- a/dash/app/src/hooks/mutation.ts
+++ b/dash/app/src/hooks/mutation.ts
@@ -58,7 +58,7 @@ export function useMutation<T, V>(
     onSettled() {
       if (options.invalidating) {
         options.invalidating.forEach((key) =>
-          queryClient.invalidateQueries(key.segments),
+          queryClient.invalidateQueries({ queryKey: key.segments }),
         );
       }
     },
@@ -79,7 +79,7 @@ export function useConfirmableDelete(
   entityType: DeleteEntity.Input['type'],
   options: MutationOptions<SuccessOutput> & { id?: UUID } = {},
 ): ConfirmableEntityAction<UUID | void> & {
-  state: 'idle' | 'loading' | 'error' | 'success';
+  state: 'idle' | 'pending' | 'error' | 'success';
 } {
   const [stateId, setStateId] = useState<UUID | undefined>();
   const mutation = useDeleteEntity(entityType, options);

--- a/dash/app/src/hooks/query.ts
+++ b/dash/app/src/hooks/query.ts
@@ -39,7 +39,7 @@ export function useOptimism(): {
   return {
     update<T>(queryKey: QueryKey<T>, to: T) {
       // cancel already in-flight queries that would overwrite optimistic update
-      queryClient.cancelQueries(queryKey.segments);
+      queryClient.cancelQueries({ queryKey: queryKey.segments });
       // update the query data to the new value
       queryClient.setQueryData(queryKey.segments, to);
     },
@@ -63,7 +63,7 @@ export function useFireAndForget<T>(
     enabled: options.when,
     retry: false,
     retryOnMount: false,
-    cacheTime: Infinity,
+    gcTime: Infinity,
     retryDelay: Infinity,
     refetchOnMount: false,
     refetchOnWindowFocus: false,

--- a/dash/app/src/hooks/zip.ts
+++ b/dash/app/src/hooks/zip.ts
@@ -4,20 +4,20 @@ import type { QueryResult } from './query';
 type ZipQueryResult<T> =
   | {
       status: `loading`;
-      isLoading: true;
+      isPending: true;
       isError: false;
       isSuccess: false;
     }
   | {
       status: `error`;
-      isLoading: false;
+      isPending: false;
       isError: true;
       isSuccess: false;
       error: PqlError;
     }
   | {
       status: `success`;
-      isLoading: false;
+      isPending: false;
       isError: false;
       isSuccess: true;
       data: T;
@@ -48,7 +48,7 @@ export function useZip<T1, T2, T3>(
   if (query3?.isError) {
     return error(query3.error);
   }
-  if (query1.isLoading || query2.isLoading || query3?.isLoading) {
+  if (query1.isPending || query2.isPending || query3?.isPending) {
     return loading();
   }
   if (query3) {
@@ -61,7 +61,7 @@ export function useZip<T1, T2, T3>(
 export function loading(): ZipQueryResult<any> {
   return {
     status: `loading`,
-    isLoading: true,
+    isPending: true,
     isError: false,
     isSuccess: false,
   };
@@ -70,7 +70,7 @@ export function loading(): ZipQueryResult<any> {
 function error(error: PqlError): ZipQueryResult<any> {
   return {
     status: `error`,
-    isLoading: false,
+    isPending: false,
     isError: true,
     isSuccess: false,
     error,
@@ -80,7 +80,7 @@ function error(error: PqlError): ZipQueryResult<any> {
 function success<T>(data: T): ZipQueryResult<T> {
   return {
     status: `success`,
-    isLoading: false,
+    isPending: false,
     isError: false,
     isSuccess: true,
     data,

--- a/dash/app/src/lib/ReqState.ts
+++ b/dash/app/src/lib/ReqState.ts
@@ -6,9 +6,9 @@ import { ensurePqlError } from '../pairql/query';
 export default class ReqState {
   static fromQuery<T>(query: QueryResult<T>): RequestState<T> {
     // disabled queries (waiting for enabled: true) are in this first state
-    if (query.isLoading && !query.isFetching) {
+    if (query.isPending && !query.isFetching) {
       return { state: `idle` };
-    } else if (query.isLoading) {
+    } else if (query.isPending) {
       return { state: `ongoing` };
     } else if (query.isError) {
       return { state: `failed`, error: ensurePqlError(query.error) };
@@ -21,7 +21,7 @@ export default class ReqState {
     switch (mutation.status) {
       case `idle`:
         return { state: `idle` };
-      case `loading`:
+      case `pending`:
         return { state: `ongoing` };
       case `error`:
         return { state: `failed`, error: ensurePqlError(mutation.error) };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,8 +159,8 @@ importers:
         specifier: workspace:*
         version: link:../../shared/ts-utils
       '@tanstack/react-query':
-        specifier: 4.29.12
-        version: 4.29.12(react-dom@18.2.0)(react@18.2.0)
+        specifier: 5.14.0
+        version: 5.14.0(react@18.2.0)
       classnames:
         specifier: ^2.3.1
         version: 2.3.2
@@ -558,7 +558,7 @@ importers:
         version: 10.4.2(postcss@8.4.32)
       babel-loader:
         specifier: ^8.2.5
-        version: 8.2.5(@babel/core@7.22.10)(webpack@5.89.0)
+        version: 8.2.5(@babel/core@7.23.5)(webpack@5.89.0)
       classnames:
         specifier: ^2.3.1
         version: 2.3.2
@@ -579,7 +579,7 @@ importers:
         version: 7.6.3
       storybook-tailwind-dark-mode:
         specifier: 1.0.22
-        version: 1.0.22(@storybook/addons@7.6.3)(@storybook/api@7.6.3)(@storybook/components@7.3.2)(@storybook/core-events@7.6.3)(@storybook/theming@7.6.3)(react-dom@18.2.0)(react@18.2.0)
+        version: 1.0.22(@storybook/addons@7.6.3)(@storybook/api@7.6.3)(@storybook/components@7.6.3)(@storybook/core-events@7.6.3)(@storybook/theming@7.6.3)(react-dom@18.2.0)(react@18.2.0)
       tailwindcss:
         specifier: 3.3.3
         version: 3.3.3(ts-node@10.9.1)
@@ -4947,17 +4947,6 @@ packages:
       - supports-color
     dev: false
 
-  /@storybook/channels@7.3.2:
-    resolution: {integrity: sha512-GG5+qzv2OZAzXonqUpJR81f2pjKExj7v5MoFJhKYgb3Y+jVYlUzBHBjhQZhuQczP4si418/jvjimvU1PZ4hqcg==}
-    dependencies:
-      '@storybook/client-logger': 7.3.2
-      '@storybook/core-events': 7.3.2
-      '@storybook/global': 5.0.0
-      qs: 6.11.0
-      telejson: 7.2.0
-      tiny-invariant: 1.3.1
-    dev: false
-
   /@storybook/channels@7.6.3:
     resolution: {integrity: sha512-o9J0TBbFon16tUlU5V6kJgzAlsloJcS1cTHWqh3VWczohbRm+X1PLNUihJ7Q8kBWXAuuJkgBu7RQH7Ib46WyYg==}
     dependencies:
@@ -5028,12 +5017,6 @@ packages:
       '@storybook/preview-api': 7.6.3
     dev: false
 
-  /@storybook/client-logger@7.3.2:
-    resolution: {integrity: sha512-T7q/YS5lPUE6xjz9EUwJ/v+KCd5KU9dl1MQ9RcH7IpM73EtQZeNSuM9/P96uKXZTf0wZOUBTXVlTzKr66ZB/RQ==}
-    dependencies:
-      '@storybook/global': 5.0.0
-    dev: false
-
   /@storybook/client-logger@7.6.3:
     resolution: {integrity: sha512-BpsCnefrBFdxD6ukMjAblm1D6zB4U5HR1I85VWw6LOqZrfzA6l/1uBxItz0XG96HTjngbvAabWf5k7ZFCx5UCg==}
     dependencies:
@@ -5059,30 +5042,6 @@ packages:
       recast: 0.23.1
     transitivePeerDependencies:
       - supports-color
-    dev: false
-
-  /@storybook/components@7.3.2(@types/react-dom@18.2.17)(@types/react@18.2.42)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-hsa1OJx4yEtLHTzrCxq8G9U5MTbcTuItj9yp1gsW9RTNc/V1n/rReQv4zE/k+//2hDsLrS62o3yhZ9VksRhLNw==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@radix-ui/react-select': 1.2.2(@types/react-dom@18.2.17)(@types/react@18.2.42)(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-toolbar': 1.0.4(@types/react-dom@18.2.17)(@types/react@18.2.42)(react-dom@18.2.0)(react@18.2.0)
-      '@storybook/client-logger': 7.3.2
-      '@storybook/csf': 0.1.2
-      '@storybook/global': 5.0.0
-      '@storybook/icons': 1.1.6(react-dom@18.2.0)(react@18.2.0)
-      '@storybook/theming': 7.3.2(react-dom@18.2.0)(react@18.2.0)
-      '@storybook/types': 7.3.2
-      memoizerific: 1.11.3
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      use-resize-observer: 9.1.0(react-dom@18.2.0)(react@18.2.0)
-      util-deprecate: 1.0.2
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
     dev: false
 
   /@storybook/components@7.6.3(@types/react-dom@18.2.17)(@types/react@18.2.42)(react-dom@18.2.0)(react@18.2.0):
@@ -5144,10 +5103,6 @@ packages:
     transitivePeerDependencies:
       - encoding
       - supports-color
-    dev: false
-
-  /@storybook/core-events@7.3.2:
-    resolution: {integrity: sha512-DCrM3s+sxLKS8vl0zB+1tZEtcl5XQTOGl46XgRRV/SIBabFbsC0l5pQPswWkTUsIqdREtiT0YUHcXB1+YDyFvA==}
     dev: false
 
   /@storybook/core-events@7.6.3:
@@ -5259,17 +5214,6 @@ packages:
 
   /@storybook/global@5.0.0:
     resolution: {integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==}
-    dev: false
-
-  /@storybook/icons@1.1.6(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-co5gDCYPojRAc5lRMnWxbjrR1V37/rTmAo9Vok4a1hDpHZIwkGTWesdzvYivSQXYFxZTpxdM1b5K3W87brnahw==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-    dependencies:
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /@storybook/manager-api@7.6.3(react-dom@18.2.0)(react@18.2.0):
@@ -5435,20 +5379,6 @@ packages:
       - supports-color
     dev: false
 
-  /@storybook/theming@7.3.2(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-npVsnmNAtqGwl1K7vLC/hcVhL8tBC8G0vdZXEcufF0jHdQmRCUs9ZVrnR6W0LCrtmIHDaDoO7PqJVSzu2wgVxw==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@emotion/use-insertion-effect-with-fallbacks': 1.0.0(react@18.2.0)
-      '@storybook/client-logger': 7.3.2
-      '@storybook/global': 5.0.0
-      memoizerific: 1.11.3
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-    dev: false
-
   /@storybook/theming@7.6.3(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-9ToNU2LM6a2kVBjOXitXEeEOuMurVLhn+uaZO1dJjv8NGnJVYiLwNPwrLsImiUD8/XXNuil972aanBR6+Aj9jw==}
     peerDependencies:
@@ -5461,15 +5391,6 @@ packages:
       memoizerific: 1.11.3
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
-
-  /@storybook/types@7.3.2:
-    resolution: {integrity: sha512-1UHC1r2J6H9dEpj4pp9a16P1rTL87V9Yc6TtYBpp7m+cxzyIZBRvu1wZFKmRB51RXE/uDaxGRKzfNRfgTALcIQ==}
-    dependencies:
-      '@storybook/channels': 7.3.2
-      '@types/babel__core': 7.20.0
-      '@types/express': 4.17.17
-      file-system-cache: 2.3.0
     dev: false
 
   /@storybook/types@7.6.3:
@@ -5508,26 +5429,17 @@ packages:
       tailwindcss: 3.3.3(ts-node@10.9.1)
     dev: false
 
-  /@tanstack/query-core@4.29.11:
-    resolution: {integrity: sha512-8C+hF6SFAb/TlFZyS9FItgNwrw4PMa7YeX+KQYe2ZAiEz6uzg6yIr+QBzPkUwZ/L0bXvGd1sufTm3wotoz+GwQ==}
+  /@tanstack/query-core@5.14.0:
+    resolution: {integrity: sha512-OEri9fVDYT8XEqgh/dc6fFp1niyqu+MDY+Vp/LwU+scdk9xQLZ7KdUMEUh/sqTEjRM5BlFzAhAv+EIYcvSxt0Q==}
     dev: false
 
-  /@tanstack/react-query@4.29.12(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-zhcN6+zF6cxprxhTHQajHGlvxgK8npnp9uLe9yaWhGc6sYcPWXzyO4raL4HomUzQOPzu3jLvkriJQ7BOrDM8vA==}
+  /@tanstack/react-query@5.14.0(react@18.2.0):
+    resolution: {integrity: sha512-+qCooNZr7aGr6a0UEblfEgDSO1y+H7h7JnT4nUlbyfgCGE695lmBiqTciuW1C1Jr6J6Z2bwyd6YmBDKFKszWhA==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-native: '*'
-    peerDependenciesMeta:
-      react-dom:
-        optional: true
-      react-native:
-        optional: true
+      react: ^18.0.0
     dependencies:
-      '@tanstack/query-core': 4.29.11
+      '@tanstack/query-core': 5.14.0
       react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
   /@tsconfig/node10@1.0.9:
@@ -6759,14 +6671,14 @@ packages:
       '@babel/core': 7.23.5
     dev: false
 
-  /babel-loader@8.2.5(@babel/core@7.22.10)(webpack@5.89.0):
+  /babel-loader@8.2.5(@babel/core@7.23.5)(webpack@5.89.0):
     resolution: {integrity: sha512-OSiFfH89LrEMiWd4pLNqGz4CwJDtbs2ZVc+iGu2HrkRfPxId9F2anQj38IxWpmRfsUY0aBZYi1EFcd3mhtRMLQ==}
     engines: {node: '>= 8.9'}
     peerDependencies:
       '@babel/core': ^7.0.0
       webpack: '>=2'
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.5
       find-cache-dir: 3.3.2
       loader-utils: 2.0.3
       make-dir: 3.1.0
@@ -12239,7 +12151,7 @@ packages:
     resolution: {integrity: sha512-siT1RiqlfQnGqgT/YzXVUNsom9S0H1OX+dpdGN1xkyYATo4I6sep5NmsRD/40s3IIOvlCq6akxkqG82urIZW1w==}
     dev: false
 
-  /storybook-tailwind-dark-mode@1.0.22(@storybook/addons@7.6.3)(@storybook/api@7.6.3)(@storybook/components@7.3.2)(@storybook/core-events@7.6.3)(@storybook/theming@7.6.3)(react-dom@18.2.0)(react@18.2.0):
+  /storybook-tailwind-dark-mode@1.0.22(@storybook/addons@7.6.3)(@storybook/api@7.6.3)(@storybook/components@7.6.3)(@storybook/core-events@7.6.3)(@storybook/theming@7.6.3)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-I0HSVCuvo3OkaGDnCjLM7V1OYmQccrUCAGZ5ZaJfl9s3e93WA6DKFpQRbuoSidci+PTy+KvgrINgE08rA16bWA==}
     peerDependencies:
       '@storybook/addons': ^7.0.0
@@ -12257,7 +12169,7 @@ packages:
     dependencies:
       '@storybook/addons': 7.6.3(react-dom@18.2.0)(react@18.2.0)
       '@storybook/api': 7.6.3(react-dom@18.2.0)(react@18.2.0)
-      '@storybook/components': 7.3.2(@types/react-dom@18.2.17)(@types/react@18.2.42)(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/components': 7.6.3(@types/react-dom@18.2.17)(@types/react@18.2.42)(react-dom@18.2.0)(react@18.2.0)
       '@storybook/core-events': 7.6.3
       '@storybook/theming': 7.6.3(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
@@ -13401,7 +13313,7 @@ packages:
       '@webassemblyjs/wasm-parser': 1.11.6
       acorn: 8.10.0
       acorn-import-assertions: 1.9.0(acorn@8.10.0)
-      browserslist: 4.21.10
+      browserslist: 4.22.2
       chrome-trace-event: 1.0.3
       enhanced-resolve: 5.15.0
       es-module-lexer: 1.4.1


### PR DESCRIPTION
closes https://github.com/gertrude-app/project/issues/201

mostly changing a bunch of `isLoading` to `isPending`, with a couple places where we were using the removed non-object overload. 

see:

* https://tanstack.com/query/v5/docs/react/guides/migrating-to-v5
* https://tanstack.com/blog/announcing-tanstack-query-v5