### PR TITLE
dash: fix google ad conversion tracking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,7 @@ jobs:
     env:
       VITE_API_ENDPOINT: ${{ secrets.STAGING_API_ENDPOINT }}
       VITE_TEST_ADMIN_CREDS: ${{ secrets.TEST_ADMIN_CREDS }}
+      VITE_GTM_ID: not-real
     steps:
       - name: reset staging # cypress tests depend slightly on staging api state
         run: curl --silent ${{ secrets.STAGING_API_RESET_ROUTE  }}; true

--- a/dash/app/index.html
+++ b/dash/app/index.html
@@ -4,10 +4,15 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Gertrude for Parents</title>
-    <meta name="description" content="Gertrude App Admin" />
+    <meta name="description" content="Gertrude for Parents" />
     <meta name="og:image" content="https://parents.gertrude.app/og-images/main.jpg" />
     <link rel="stylesheet" type="text/css" href="/src/global.css" />
     <link rel="icon" type="image/png" href="/src/public/favicon.png" />
+    <link
+      rel="preload"
+      href="https://www.googletagmanager.com/gtm.js?id=%VITE_GTM_ID%"
+      as="script"
+    />
   </head>
   <body class="h-full">
     <div id="root"></div>

--- a/dash/app/package.json
+++ b/dash/app/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "start": "vite",
+    "start": "VITE_GTM_ID=not-real vite",
     "build": "vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",

--- a/dash/app/src/components/routes/UseCaseSurvey.tsx
+++ b/dash/app/src/components/routes/UseCaseSurvey.tsx
@@ -141,8 +141,8 @@ const Option: React.FC<OptionProps> = ({ children, type, description, setPage })
   return (
     <button
       data-track-conversion={type === `self` ? undefined : true}
-      onClick={() => {
-        Current.api.logEvent({
+      onClick={async () => {
+        await Current.api.logEvent({
           eventId: `bc6213cb`,
           detail: `signup use-case survey click: *${type.toUpperCase()}*`,
         });


### PR DESCRIPTION
broken when i switched to cloudflare, i think because netlify has snippet injection, and cloudflare does not.

closes https://github.com/gertrude-app/project/issues/269